### PR TITLE
Fixed usernames consisting of all spaces.

### DIFF
--- a/core/Helpers.cs
+++ b/core/Helpers.cs
@@ -173,6 +173,8 @@ namespace core
             if (client.OrgName == Settings.Get<String>("bot"))
                 client.OrgName = String.Empty;
 
+            client.OrgName = client.OrgName.Trim();
+
             client.OrgName = Regex.Replace(client.OrgName, Regex.Escape("_"), " ", RegexOptions.IgnoreCase);
             client.OrgName = Regex.Replace(client.OrgName, Regex.Escape("\""), String.Empty, RegexOptions.IgnoreCase);
             client.OrgName = Regex.Replace(client.OrgName, Regex.Escape("/"), String.Empty, RegexOptions.IgnoreCase);
@@ -182,7 +184,7 @@ namespace core
             while (Encoding.UTF8.GetByteCount(client.OrgName) > 20)
                 client.OrgName = client.OrgName.Substring(0, client.OrgName.Length - 1);
 
-            if (client.OrgName.Length < 2)
+            if (client.OrgName.Length < 2 || string.IsNullOrWhiteSpace(client.OrgName))
             {
                 client.OrgName = client.WebClient ? "ib0t" : "anon ";
 


### PR DESCRIPTION
Prior to change usernames consisting of underscores get converted to just space allowing a "blank" username.